### PR TITLE
feat: hide scrollbars, fix collection header image layout | 986

### DIFF
--- a/src/components/Layout/AppLayout.module.scss
+++ b/src/components/Layout/AppLayout.module.scss
@@ -13,11 +13,6 @@
 .content {
   display: flex;
   overflow-x: clip;
-
-  @media (min-width: 1025px) {
-    overflow-y: hidden;
-    margin-right: -17px;
-  }
 }
 
 .mainWrapper {
@@ -25,7 +20,6 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  overflow-x: hidden;
   padding-inline: var(--body-offset-desktop);
   margin-bottom: var(--body-offset-desktop);
 

--- a/src/components/Layout/AppLayout.module.scss
+++ b/src/components/Layout/AppLayout.module.scss
@@ -1,11 +1,23 @@
 .layoutWrapper {
   display: flex;
   flex-direction: column;
+
+  @media (min-width: 1025px) {
+    overflow-x: hidden;
+    overflow-y: scroll;
+    height: 100vh;
+    margin-right: -17px;
+  }
 }
 
 .content {
   display: flex;
   overflow-x: clip;
+
+  @media (min-width: 1025px) {
+    overflow-y: hidden;
+    margin-right: -17px;
+  }
 }
 
 .mainWrapper {

--- a/src/pages/Collection/components/CollectionHeader/styles.module.scss
+++ b/src/pages/Collection/components/CollectionHeader/styles.module.scss
@@ -23,6 +23,14 @@
   width: 100vw;
   height: 100%;
   z-index: -1;
+
+  @media (max-width: 1024px) {
+    left: calc(0px - var(--body-offset-small-screen));
+  }
+
+  @media (max-width: 768px) {
+    left: calc(0px - var(--body-offset-tablet));
+  }
 }
 
 .coverImage {

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -6,6 +6,12 @@
   color: var(--primary-white-color);
 }
 
+body {
+  @media (min-width: 1025px) {
+    overflow: hidden;
+  }
+}
+
 a {
   &,
   &:hover,


### PR DESCRIPTION
## Description

hide scrollbars, fixed the gap between an image and the right side of the screen on the collection header.

## Screenshots

<img width="453" alt="Screen Shot 2023-02-14 at 15 18 04" src="https://user-images.githubusercontent.com/47819058/218693233-33bb07ad-b0cf-46c3-9254-6dc55489f4f0.png">

## Environment link

[Link](https://hadeswap-git-feature-devs-986-frakt.vercel.app/)

## Jira issue link

[DEVS-986](https://frakt-nft.atlassian.net/browse/DEVS-986)